### PR TITLE
Remove deprecated `LOG_DIR` and `HOST_SETTINGS_LOG_DIR` parameters

### DIFF
--- a/en/node-operators-guide/data-feed.md
+++ b/en/node-operators-guide/data-feed.md
@@ -78,11 +78,9 @@ Before we launch the **Orakl Network Data Feed**, we must specify [several envir
 * `PROVIDER_URL`
 * `ORAKL_NETWORK_API_URL`
 * `LOG_LEVEL`
-* `LOG_DIR`
-* `REDIS_HOST`&#x20;
+* `REDIS_HOST`
 * `REDIS_PORT`
 * `HEALTH_CHECK_PORT`
-* `HOST_SETTINGS_LOG_DIR`
 * `SLACK_WEBHOOK_URL`
 
 The **Orakl Network Data Feed** is implemented in Node.js which uses `NODE_ENV` environment variable to signal the execution environment (e.g. `production`, `development`). [Setting the environment to `production`](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/) generally ensures that logging is kept to a minimum, and more caching levels take place to optimize performance.
@@ -95,13 +93,9 @@ The **Orakl Network Data Feed** is implemented in Node.js which uses `NODE_ENV` 
 
 Setting a level of logs emitted by a running instance is set through `LOG_LEVEL` environment variable, and can be one of the following: `error`, `warning`, `info`, `debug` and `trace`, ordered from the most restrictive to the least. By selecting any of the available options you subscribe to the specified level and all levels with lower restrictiveness.
 
-Logs are sent to console, and to file which is located at `LOG_DIR` directory.
-
 `REDIS_HOST` and `REDIS_PORT` represent host and port of [Redis](https://redis.io/) to which all **Orakl Network Data Feed** microservices connect. The default values are `localhost` and `6379`, respectively.&#x20;
 
 The **Orakl Network Data Feed** does not offer a rich REST API, but defines a health check endpoint (`/`) served under a port denoted as `HEALTH_CHECK_PORT`.
-
-`HOST_SETTINGS_LOG_DIR` is used in [Docker Compose file](https://github.com/Bisonai/orakl/blob/master/core/docker-compose.data-feed.yaml), and represents a location at host where collected log files will be stored.
 
 Errors and warnings emitted by the **Orakl Network Data Feed** can be [sent to Slack channels through a slack webhook](https://api.slack.com/messaging/webhooks). The webhook URL can be set with the `SLACK_WEBOOK_URL` environment variable.
 

--- a/en/node-operators-guide/helmchart.md
+++ b/en/node-operators-guide/helmchart.md
@@ -35,7 +35,7 @@ AWS Installation
 helm install storage -n orakl orakl/orakl-log-aws-storage \
     --set "config.efsFileSystemId=${your efs file system id}" \
     --set "config.region=${your aws resion}" \
-    --set "config.size=100Gi" 
+    --set "config.size=100Gi"
 ```
 
 GCP Installation
@@ -73,7 +73,7 @@ helm install fetcher -n orakl orakl/orakl-fetcher \
     --set "global.config.APP_PORT=4040" \
     --set "global.config.REDIS_HOST=${your redis host address }" \
     --set "global.config.REDIS_PORT=${your redis port | 6379}" \
-    --set "global.config.ORAKL_NETWORK_API_URL=http://orakl-api.orakl.svc.cluster.local:3030/api/v1" 
+    --set "global.config.ORAKL_NETWORK_API_URL=http://orakl-api.orakl.svc.cluster.local:3030/api/v1"
 ```
 
 + `ORAKL_NETWORK_API_URL`: This is the address to communicate with the Pod you installed in step 03. It uses the usual Kubernetes domain for communication, which is `http://{api pod's service name}.{namespace}.svc.cluster.local:3030/api/v1` So if you installed in a namespace other than the orakl namespace, the address of the API server will need to be changed, for example, if the namespace is default, it will be `http://orakl-api.default.svc.cluster.local:3030/api/v1`
@@ -85,11 +85,11 @@ helm install fetcher -n orakl orakl/orakl-fetcher \
 helm install cli -n orakl orakl/orakl-cli \
     --set "global.config.ORAKL_NETWORK_API_URL=http://orakl-api.orakl.svc.cluster.local:3030/api/v1" \
     --set "global.config.ORAKL_NETWORK_FETCHER_URL=http://orakl-fetcher.orakl.svc.cluster.local:4040/api/v1" \
-    --set "global.config.ORAKL_NETWORK_DELEGATOR_URL=http://orakl-delegator.orakl.svc.cluster.local:5050/api/v1" 
+    --set "global.config.ORAKL_NETWORK_DELEGATOR_URL=http://orakl-delegator.orakl.svc.cluster.local:5050/api/v1"
 ```
 
 + `ORAKL_NETWORK_API_URL`, `ORAKL_NETWORK_FETCHER_URL` : These 2 URLs are the same convention we used to deploy the fetcher earlier, just make sure to include the service name and namespace.
-+ 
++
 + `ORAKL_NETWORK_DELEGATOR_URL` : This URL will be available soon. The parts related to Delegator are in the process of being migrated.
 
 
@@ -98,12 +98,12 @@ helm install cli -n orakl orakl/orakl-cli \
 If you look at the aggregator Baobab at https://config.orakl.network/, there are 12 contracts and each contract has an address. There will be more later. We have to have 12 accounts to whitelist in this contract if you want to activate reporters account. To activate your account, kindly reach out to us at business@orakl.network.
 
 + list all pods in orakl namespace
-  ```bash 
-    kubectl get pods -n orakl 
+  ```bash
+    kubectl get pods -n orakl
   ```
 + access to cli pod
   ```bash
-    kubectl exec -it cli-7b8df47f-bdlzv -n orakl -- /bin/bash 
+    kubectl exec -it cli-7b8df47f-bdlzv -n orakl -- /bin/bash
   ```
 
     You can set the default settings through the [orakl cli part](https://docs.orakl.network/docs/node-operators-guide/cli). Here we'll show you an example.
@@ -179,7 +179,7 @@ If you look at the aggregator Baobab at https://config.orakl.network/, there are
 *   setting reporter
 
     ```bash
-    yarn cli reporter insert \ 
+    yarn cli reporter insert \
       --chain baobab \
       --service DATA_FEED \
       --address ${your reporter account address} \
@@ -244,12 +244,11 @@ If you look at the aggregator Baobab at https://config.orakl.network/, there are
 ```bash
   helm install aggregator -n orakl orakl/orakl-aggregator \
     --set "global.config.CHAIN=${your network name}" \
-    --set "global.config.LOG_DIR=/app/log" \    
-    --set "global.config.LOG_LEVEL=info" \        
+    --set "global.config.LOG_LEVEL=info" \
     --set "global.config.HEALTH_CHECK_PORT=8080" \
-    --set "global.config.NODE_ENV=production" \            
-    --set "global.config.ORAKL_NETWORK_API_URL=http://orakl-api.orakl.svc.cluster.local:3030/api/v1" \                
-    --set "global.config.ORAKL_NETWORK_DELEGATOR_URL=http://orakl-delegator.orakl.svc.cluster.local:5050/api/v1" \                    
+    --set "global.config.NODE_ENV=production" \
+    --set "global.config.ORAKL_NETWORK_API_URL=http://orakl-api.orakl.svc.cluster.local:3030/api/v1" \
+    --set "global.config.ORAKL_NETWORK_DELEGATOR_URL=http://orakl-delegator.orakl.svc.cluster.local:5050/api/v1" \
     --set "global.config.PROVIDER_URL=${your network provider url}" \
     --set "global.config.REDIS_HOST=${your redis host}" \
     --set "global.config.REDIS_PORT=${your redis port}" \

--- a/en/node-operators-guide/kubernetes.md
+++ b/en/node-operators-guide/kubernetes.md
@@ -37,15 +37,9 @@ helm install \
  --set CHAIN=localhost \
  --set ORAKL_DIR=/app/db \
  --set LOG_LEVEL=debug \
- --set LOG_DIR=/app/log \
  orakl-cli orakl/orakl-cli
 ```
-
-
 
 After the successful deployment of `orakl-cli`, set up the configuration before installing VRF or Request-Response.
 
 #### 3) Setting configuration
-
-
-

--- a/en/node-operators-guide/request-response.md
+++ b/en/node-operators-guide/request-response.md
@@ -44,11 +44,9 @@ Before we launch the **Orakl Network Request-Response**, we must specify [severa
 * `PROVIDER_URL`
 * `ORAKL_NETWORK_API_URL`
 * `LOG_LEVEL`
-* `LOG_DIR`
 * `REDIS_HOST`
 * `REDIS_PORT`
 * `HEALTH_CHECK_PORT`
-* `HOST_SETTINGS_LOG_DIR`
 * `SLACK_WEBHOOK_URL`
 
 The **Orakl Network Request-Response** is implemented in Node.js which uses `NODE_ENV` environment variable to signal the execution environment (e.g. `production`, `development`). [Setting the environment to `production`](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/) generally ensures that logging is kept to a minimum, and more caching levels take place to optimize performance.
@@ -61,13 +59,9 @@ The **Orakl Network Request-Response** is implemented in Node.js which uses `NOD
 
 Setting a level of logs emitted by a running instance is set through `LOG_LEVEL` environment variable, and can be one of the following: `error`, `warning`, `info`, `debug` and `trace`, ordered from the most restrictive to the least. By selecting any of the available options you subscribe to the specified level and all levels with lower restrictiveness.
 
-Logs are sent to console, and to file which is located at `LOG_DIR` directory.
-
 `REDIS_HOST` and `REDIS_PORT` represent host and port of [Redis](https://redis.io/) to which all **Orakl Network Request-Response** microservices connect. The default values are `localhost` and `6379`, respectively.&#x20;
 
 The **Orakl Network Request-Response** does not offer a rich REST API, but defines a health check endpoint (`/`) served under a port denoted as `HEALTH_CHECK_PORT`.
-
-`HOST_SETTINGS_LOG_DIR` is used in [Docker Compose file](https://github.com/Bisonai/orakl/blob/master/core/docker-compose.request-response.yaml), and represents a location at host where collected log files will be stored.
 
 Errors and warnings emitted by the **Orakl Network Request-Response** can be [sent to Slack channels through a slack webhook](https://api.slack.com/messaging/webhooks). The webhook URL can be set with the `SLACK_WEBOOK_URL` environment variable.
 
@@ -88,4 +82,3 @@ yarn start:reporter:request_response
 The architecture is very similar to the **Orakl Network VRF**. The only difference is that the **Orakl Network Request-Response Worker** fetches and processes data based on the on-chain request.
 
 <figure><img src="../.gitbook/assets/orakl-network-request-response.png" alt=""><figcaption><p>Orakl Network Request-Response</p></figcaption></figure>
-

--- a/en/node-operators-guide/vrf.md
+++ b/en/node-operators-guide/vrf.md
@@ -76,11 +76,9 @@ Before we launch the **Orakl Network VRF**, we must specify [several environment
 * `PROVIDER_URL`
 * `ORAKL_NETWORK_API_URL`
 * `LOG_LEVEL`
-* `LOG_DIR`
 * `REDIS_HOST`
 * `REDIS_PORT`
 * `HEALTH_CHECK_PORT`
-* `HOST_SETTINGS_LOG_DIR`
 * `SLACK_WEBHOOK_URL`
 
 The **Orakl Network VRF** is implemented in Node.js which uses `NODE_ENV` environment variable to signal the execution environment (e.g. `production`, `development`). [Setting the environment to `production`](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/) generally ensures that logging is kept to a minimum, and more caching levels take place to optimize performance.
@@ -93,13 +91,9 @@ The **Orakl Network VRF** is implemented in Node.js which uses `NODE_ENV` enviro
 
 Setting a level of logs emitted by a running instance is set through `LOG_LEVEL` environment variable, and can be one of the following: `error`, `warning`, `info`, `debug` and `trace`, ordered from the most restrictive to the least. By selecting any of the available options you subscribe to the specified level and all levels with lower restrictiveness.
 
-Logs are sent to console, and to file which is located at `LOG_DIR` directory.
-
 `REDIS_HOST` and `REDIS_PORT` represent host and port of [Redis](https://redis.io/) to which all **Orakl Network VRF** microservices connect. The default values are `localhost` and `6379`, respectively.&#x20;
 
 The **Orakl Network VRF** does not offer a rich REST API, but defines a health check endpoint (`/`) served under a port denoted as `HEALTH_CHECK_PORT`.
-
-`HOST_SETTINGS_LOG_DIR` is used in [Docker Compose file](https://github.com/Bisonai/orakl/blob/master/core/docker-compose.vrf.yaml), and represents a location at host where collected log files will be stored.
 
 Errors and warnings emitted by the **Orakl Network VRF** can be [sent to Slack channels through a slack webhook](https://api.slack.com/messaging/webhooks). The webhook URL can be set with the `SLACK_WEBOOK_URL` environment variable.
 

--- a/kr/node-operators-guide/data-feed.md
+++ b/kr/node-operators-guide/data-feed.md
@@ -66,11 +66,9 @@ orakl-cli aggregator insert \
 - `PROVIDER_URL`
 - `ORAKL_NETWORK_API_URL`
 - `LOG_LEVEL`
-- `LOG_DIR`
-- `REDIS_HOST`&#x20;
+- `REDIS_HOST`
 - `REDIS_PORT`
 - `HEALTH_CHECK_PORT`
-- `HOST_SETTINGS_LOG_DIR`
 - `SLACK_WEBHOOK_URL`
 
 **Orakl Network Data Feed** 는 Node.js로 구현되어 있으며, 실행 환경을 나타내는 `NODE_ENV` 환경 변수를 사용합니다 (예: `production`, `development`). [환경을 `production` 으로 설정](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/)하면 일반적으로 로깅이 최소화되고 성능을 최적화하기 위해 더 많은 캐싱 수준이 적용됩니다.
@@ -83,13 +81,9 @@ orakl-cli aggregator insert \
 
 실행 중인 인스턴스에서 발생하는 로그의 수준은 `LOG_LEVEL` 환경 변수를 통해 설정되며 다음 중 하나일 수 있습니다: `error`, `warning`, `info`, `debug` 또는 `trace` 입니다. 가장 제한적인 것부터 가장 제한적이지 않은 것까지 순서대로 정렬되어 있습니다. 이용 가능한 옵션 중 하나를 선택하면 해당 수준과 더 낮은 제한 수준의 모든 로그를 구독하게 됩니다.
 
-로그들은 콘솔과 `LOG_DIR` 디렉토리에 있는 파일로 전송됩니다.
-
 `REDIS_HOST` 와 `REDIS_PORT`는 **Orakl Network Data Feed** 마이크로서비스가 연결하는 [Redis](https://redis.io/)의 호스트와 포트를 나타냅니다. 기본값은 각각 `localhost` 와 `6379` 입니다.&#x20;
 
 **Orakl Network Data Feed** 는 풍부한 REST API를 제공하지 않지만, `HEALTH_CHECK_PORT` 로 지정된 포트에서 제공되는 헬스 체크 엔드포인트 (`/`) 를 정의합니다.
-
-`HOST_SETTINGS_LOG_DIR` 은 [Docker Compose 파일](https://github.com/Bisonai/orakl/blob/master/core/docker-compose.data-feed.yaml)에서 사용되며, 수집된 로그 파일이 호스트에서 저장될 위치를 나타냅니다.
 
 **Orakl Network Data Feed** 에서 발생하는 오류와 경고를 [Slack 웹훅을 통해 Slack 채널로 전송](https://api.slack.com/messaging/webhooks)할 수 있습니다. 웹훅 URL은 `SLACK_WEBOOK_URL` 환경 변수를 사용하여 설정할 수 있습니다.
 

--- a/kr/node-operators-guide/helmchart.md
+++ b/kr/node-operators-guide/helmchart.md
@@ -254,7 +254,6 @@ Aggregator Baobab에서 https://config.orakl.network/ 을 확인해보면 12개�
 ```bash
   helm install aggregator -n orakl orakl/orakl-aggregator \
     --set "global.config.CHAIN=${your network name}" \
-    --set "global.config.LOG_DIR=/app/log" \
     --set "global.config.LOG_LEVEL=info" \
     --set "global.config.HEALTH_CHECK_PORT=8080" \
     --set "global.config.NODE_ENV=production" \

--- a/kr/node-operators-guide/request-response.md
+++ b/kr/node-operators-guide/request-response.md
@@ -44,11 +44,9 @@ orakl-cli reporter insert \
 - `PROVIDER_URL`
 - `ORAKL_NETWORK_API_URL`
 - `LOG_LEVEL`
-- `LOG_DIR`
 - `REDIS_HOST`
 - `REDIS_PORT`
 - `HEALTH_CHECK_PORT`
-- `HOST_SETTINGS_LOG_DIR`
 - `SLACK_WEBHOOK_URL`
 
 **Orakl Network Request-Response** 는 Node.js로 구현되어 있으며, 실행 환경을 나타내는 `NODE_ENV` 환경 변수를 사용합니다 (예: `production`, `development`). [환경을 `production` 으로 설정](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/)하면 일반적으로 로깅이 최소화되고 성능을 최적화하기 위해 더 많은 캐싱 수준이 적용됩니다.
@@ -61,13 +59,9 @@ orakl-cli reporter insert \
 
 실행 중인 인스턴스에서 발생하는 로그의 수준은 `LOG_LEVEL` 환경 변수를 통해 설정되며 다음 중 하나일 수 있습니다: `error`, `warning`, `info`, `debug` 또는 `trace` 입니다. 가장 제한적인 것부터 가장 제한적이지 않은 것까지 순서대로 정렬되어 있습니다. 이용 가능한 옵션 중 하나를 선택하면 해당 수준과 더 낮은 제한 수준의 모든 로그를 구독하게 됩니다.
 
-로그들은 콘솔과 `LOG_DIR` 디렉토리에 있는 파일로 전송됩니다.
-
 `REDIS_HOST` 와 `REDIS_PORT`는 **Orakl Network Request-Response** 마이크로서비스가 연결하는 [Redis](https://redis.io/)의 호스트와 포트를 나타냅니다. 기본값은 각각 `localhost` 와 `6379` 입니다.&#x20;
 
 **Orakl Network Request-Response** 는 풍부한 REST API를 제공하지 않지만, `HEALTH_CHECK_PORT` 로 지정된 포트에서 제공되는 헬스 체크 엔드포인트 (`/`) 를 정의합니다.
-
-`HOST_SETTINGS_LOG_DIR` 은 [Docker Compose 파일](https://github.com/Bisonai/orakl/blob/master/core/docker-compose.request-response.yaml)에서 사용되며, 수집된 로그 파일이 호스트에서 저장될 위치를 나타냅니다.
 
 **Orakl Network Request-Response** 에서 발생하는 오류와 경고를 [Slack 웹훅을 통해 Slack 채널로 전송](https://api.slack.com/messaging/webhooks)할 수 있습니다. 웹훅 URL은 `SLACK_WEBOOK_URL` 환경 변수를 사용하여 설정할 수 있습니다.
 

--- a/kr/node-operators-guide/vrf.md
+++ b/kr/node-operators-guide/vrf.md
@@ -76,11 +76,9 @@ orakl-cli vrf insert \
 - `PROVIDER_URL`
 - `ORAKL_NETWORK_API_URL`
 - `LOG_LEVEL`
-- `LOG_DIR`
 - `REDIS_HOST`
 - `REDIS_PORT`
 - `HEALTH_CHECK_PORT`
-- `HOST_SETTINGS_LOG_DIR`
 - `SLACK_WEBHOOK_URL`
 
 **Orakl Network VRF** 는 Node.js로 구현되어 있으며, 실행 환경을 나타내는 `NODE_ENV` 환경 변수를 사용합니다 (예: `production`, `development`). [환경을 `production` 으로 설정](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/)하면 일반적으로 로깅이 최소화되고 성능을 최적화하기 위해 더 많은 캐싱 수준이 적용됩니다.
@@ -93,13 +91,9 @@ orakl-cli vrf insert \
 
 실행 중인 인스턴스에서 발생하는 로그의 수준은 `LOG_LEVEL` 환경 변수를 통해 설정되며 다음 중 하나일 수 있습니다: `error`, `warning`, `info`, `debug` 또는 `trace` 입니다. 가장 제한적인 것부터 가장 제한적이지 않은 것까지 순서대로 정렬되어 있습니다. 이용 가능한 옵션 중 하나를 선택하면 해당 수준과 더 낮은 제한 수준의 모든 로그를 구독하게 됩니다.
 
-로그들은 콘솔과 `LOG_DIR` 디렉토리에 있는 파일로 전송됩니다.
-
 `REDIS_HOST` 와 `REDIS_PORT`는 **Orakl Network VRF** 마이크로서비스가 연결하는 [Redis](https://redis.io/)의 호스트와 포트를 나타냅니다. 기본값은 각각 `localhost` 와 `6379` 입니다.&#x20;
 
 **Orakl Network VRF** 는 풍부한 REST API를 제공하지 않지만, `HEALTH_CHECK_PORT` 로 지정된 포트에서 제공되는 헬스 체크 엔드포인트 (`/`) 를 정의합니다.
-
-`HOST_SETTINGS_LOG_DIR` 은 [Docker Compose 파일](https://github.com/Bisonai/orakl/blob/master/core/docker-compose.vrf.yaml)에서 사용되며, 수집된 로그 파일이 호스트에서 저장될 위치를 나타냅니다.
 
 **Orakl Network VRF** 에서 발생하는 오류와 경고를 [Slack 웹훅을 통해 Slack 채널로 전송](https://api.slack.com/messaging/webhooks)할 수 있습니다. 웹훅 URL은 `SLACK_WEBOOK_URL` 환경 변수를 사용하여 설정할 수 있습니다.
 


### PR DESCRIPTION
This PR removed deprecated parameters: `LOG_DIR` and `HOST_SETTING_LOG_DIR`.